### PR TITLE
Just a site map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Got lost?
 
-Hi 👋! There is nothing here behind this URL. Maybe you were looking for:
+Hi 👋! There is nothing behind this URL. Maybe you were looking for:
 
-- [wiki](https://tuni-itc.github.io/wiki/)
+- [tuni-itc.github.io/**wiki**/](https://tuni-itc.github.io/wiki/)
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# tuni-itc.github.io
+# Got lost?
+
+Hi 👋! There is nothing here behind this URL. Maybe you were looking for:
+
+- [wiki](https://tuni-itc.github.io/wiki/)
+


### PR DESCRIPTION
Just a site map for those who tried the root URL ([tuni-itc.github.io](https://tuni-itc.github.io/)) instead of the specified ones (for now [tuni-itc.github.io/wiki](https://tuni-itc.github.io/wiki)).